### PR TITLE
Don't put the build directory name into man page title

### DIFF
--- a/src/cmake/pod2man-wrapper.pl
+++ b/src/cmake/pod2man-wrapper.pl
@@ -6,6 +6,7 @@ use warnings;
 use Getopt::Long;
 use File::Temp qw/tempdir/;
 use File::Copy;
+use File::Basename;
 
 my ($src, $dest, $sect, $center, $release);
 
@@ -45,13 +46,23 @@ if (!defined($release))
 
 my $dir = tempdir( CLEANUP => 1);
 
-my $pod = "$dir/Hoola.pod";
+my $pod;
+if ($src =~ m(/wml_include/)) {
+    $pod = $src;
+    $pod =~ s(^.*/wml_include/)(wml::);
+    $pod =~ s(/)(::)g;
+    $pod =~ s(\.(src|pl|pm|pod)$)();
+} else {
+    $pod = basename($src, '.src', '.pl', '.pm', '.pod');
+}
+$pod = "$pod.pod";
 
 if (! -e $src)
 {
     die "Cannot find '$src'";
 }
-copy($src, $pod);
+copy($src, "$dir/$pod");
+chdir($dir);
 
 if(
 system(


### PR DESCRIPTION
Also remove "Hoola" from the man page title and replace it with a proper man page name.

Without this patch the the head line of the `wml(1)` man page (as generated from POD by `cmake/pod2man-wrapper.pl`) looks like this:

```
HOOLA(1)                     EN Tools                     HOOLA(1)
```

And the man page `wml::des::imgbg(3)` looks even worse:

```
tmp::ho1p32hifo::Hoola(3)    EN Tools    tmp::ho1p32hifo::Hoola(3)
```

With this patch the man page titles look like they should:

```
WML(1)                       EN Tools                       WML(1)
```

```
wml::des::imgbg(3)           EN Tools           wml::des::imgbg(3)
```

Not having the build directory path in any of the resulting files is additionally necessary to make the build reproducible. See https://reproducible-builds.org/

P.S.: I've got one more patch wrt. to reproducible builds more or less ready. But since it solely removes stuff (which might be considered a feature), I'll file a separate pull request for it. (Edit: Became PR #21)