### PR TITLE
 Drop hardcoded date, user and host strings in wml

### DIFF
--- a/src/cmake/pod2man-wrapper.pl
+++ b/src/cmake/pod2man-wrapper.pl
@@ -6,6 +6,7 @@ use warnings;
 use Getopt::Long;
 use File::Temp qw/tempdir/;
 use File::Copy;
+use File::Basename;
 
 my ($src, $dest, $sect, $center, $release);
 
@@ -45,13 +46,23 @@ if (!defined($release))
 
 my $dir = tempdir( CLEANUP => 1);
 
-my $pod = "$dir/Hoola.pod";
+my $pod;
+if ($src =~ m(/wml_include/)) {
+    $pod = $src;
+    $pod =~ s(^.*/wml_include/)(wml::);
+    $pod =~ s(/)(::)g;
+    $pod =~ s(\.(src|pl|pm|pod)$)();
+} else {
+    $pod = basename($src, '.src', '.pl', '.pm', '.pod');
+}
+$pod = "$pod.pod";
 
 if (! -e $src)
 {
     die "Cannot find '$src'";
 }
-copy($src, $pod);
+copy($src, "$dir/$pod");
+chdir($dir);
 
 if(
 system(

--- a/src/wml_include/TheWML/Config.pm.src
+++ b/src/wml_include/TheWML/Config.pm.src
@@ -22,10 +22,7 @@ sub build_info
 {
     return <<'EOF';
 Built Environment:
-    Host: @built_system@
     Perl: @perlvers@ (@perlprog@)
-    User: @built_user@
-    Date: @built_date@
 Built Location:
     Prefix: @prefix@
     BinDir: @bindir@


### PR DESCRIPTION
Drop those lines where configure inserts hardcoded build date, user name and host name to make the build more easily reproducible.

See https://reproducible-builds.org/ for the background.

This pull request is currently based upon #20 as it IMHO doesn't make much sense without it. I hope that's ok.