### PR TITLE
Add CMake check for List::MoreUtils

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ SET (CPAN_MODULES_TO_CHECK
     "Getopt::Long"
     "Image::Size"
     "IO::All"
+    "List::MoreUtils"
     "Path::Tiny"
     "Term::ReadKey"
     "Time::HiRes"


### PR DESCRIPTION
`List::MoreUtils` is used in `TheWML::Backends::Divert::Main` and `src/wml_test/t/build-process.t`. This was triggered by [Debian bug report #918398](https://bugs.debian.org/918398).

BTW: `Test::Code::TidyAll` is also required to run the test suite despite #4 being fixed, since the check comes after the `use` respectively the check and `use` are not inside a `BEGIN` block or so. Not sure if or how this should be fixed best.