### PR TITLE
Fix typo reported by Debian's lintian tool

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -239,7 +239,7 @@
       - System variables like WML_GEN_HOSTNAME now can be
         overwritten by -D options on the command line or in
         .wmlrc files. For instance this is useful to overwrite
-        informations for the <info> tag from wml::std::info with
+        information for the <info> tag from wml::std::info with
         correct values.
 
       - Various 3rd-party software upgrades:

--- a/src/wml_backend/p2_mp4h/doc/mp4h.mp4h
+++ b/src/wml_backend/p2_mp4h/doc/mp4h.mp4h
@@ -836,7 +836,7 @@ it is set to the second argument.
 </tag:description>
 
 <para>
-Show informations on symbols.  If it is a variable name, the <command
+Show information on symbols.  If it is a variable name, the <command
 STRING /> word is printed as well as the number of lines contained within
 this variable.
 
@@ -1892,7 +1892,7 @@ Returns <true/> if file exists.
 </tag:description>
 
 <para>
-Returns an array of informations on this file.  These informations are:
+Returns an array of information on this file.  These information are:
 size, type, ctime, mtime, atime, owner and group.
 </para>
 
@@ -2158,7 +2158,7 @@ being processed.
 </tag:description>
 
 <para>
-Declare these macros traced, i.e. informations about these macros will
+Declare these macros traced, i.e. information about these macros will
 be printed if <optflag d /> flag or <command debugmode /> macro are used.
 </para>
 
@@ -2652,7 +2652,7 @@ and footers with
 <define-tag header>
 <html*>
 <head>
-... put here some informations ....
+... put here some information ....
 </head>
 <body* bgcolor="#ffffff" text="#000000">
 </define-tag>

--- a/src/wml_backend/p2_mp4h/src/builtin.c
+++ b/src/wml_backend/p2_mp4h/src/builtin.c
@@ -1299,7 +1299,7 @@ mp4h_bp_function_def (MP4H_BUILTIN_ARGS)
 #ifdef HAVE_FILE_FUNCS
 
 /*-----------------------------------------------------------------.
-| Informations on a file.  A newline separated string is printed:  |
+| Information on a file.  A newline separated string is printed:   |
 |    Line 1: file size                                             |
 |    Line 2: file type                                             |
 |    Line 3: time of last change                                   |
@@ -4266,7 +4266,7 @@ mp4h_bp_decrement (MP4H_BUILTIN_ARGS)
 }
 
 /*--------------------------------.
-| Dumps informations of symbols.  |
+| Dumps information of symbols.   |
 `--------------------------------*/
 static void
 mp4h_bp_symbol_info (MP4H_BUILTIN_ARGS)

--- a/src/wml_backend/p9_slice/slice.pod
+++ b/src/wml_backend/p9_slice/slice.pod
@@ -220,7 +220,7 @@ files on a webserver with the C<XBitHack> option available).
 
 The optional I<outputpolicy> string allows changing output policy for
 only this output file without changing its global meaning.  See above
-for informations on output policy.
+for information on output policy.
 
 Be careful here: When you use parenthesis or asterisks inside I<sliceterm> you
 have to make sure it is really passed to F<slice> this way, i.e. usually you


### PR DESCRIPTION
It's a single typo, but present in many files. (A common typo for people who speak German as mother tongue.)