### PR TITLE
Disable feature "unicode_strings" in pass 8 (htmlstrip)

### DIFF
--- a/src/wml_include/TheWML/Backends/HtmlStrip/Main.pm
+++ b/src/wml_include/TheWML/Backends/HtmlStrip/Main.pm
@@ -8,6 +8,8 @@ use strict;
 use warnings;
 use 5.014;
 
+no feature qw(unicode_strings);
+
 use parent 'TheWML::CmdLine::Base';
 
 use Getopt::Long ();


### PR DESCRIPTION
It only works properly if file handles are set to `utf8 binmode` and we can't expect that all input and output is UTF-8. So disable it completely and go back to classic Perl ASCII-only `\s` meaning.

See also Debian bug-report https://bugs.debian.org/959761

Source: https://salsa.debian.org/debian/wml/-/blob/master/debian/patches/fix-unicode-handling-in-htmlstrip.patch